### PR TITLE
Update how to use it

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,8 @@ Now you can use it like this:
 
 .. code:: bash
 
-   $ mrbob https://github.com/datakurre/plonetheme.webpacktemplate/archive/master.zip
+   $ git clone https://github.com/datakurre/plonetheme.webpacktemplate.git
+   $ mrbob plonetheme.webpacktemplate
 
 See `the documentation of mr.bob <http://mrbob.readthedocs.org/en/latest/>`_  for further information.
 


### PR DESCRIPTION
Giving mrbob the URL of the zipped repo as template does not work, because github seems to leave out files starting with a dot in the zip files. 
Errormessage: 
`mrbob: error: TemplateConfigurationError: Config not found: /tmp/tmpBP6yKx/.mrbob.ini`
Cloning the repo makes and providing the folder makes sure that .mrbob.ini is there
