### PR TITLE
A couple of fixes for default diazo rules

### DIFF
--- a/+package.dottedname+/resources/src/+theme.folder+/rules.xml.bob
+++ b/+package.dottedname+/resources/src/+theme.folder+/rules.xml.bob
@@ -3,7 +3,8 @@
     xmlns="http://namespaces.plone.org/diazo"
     xmlns:css="http://namespaces.plone.org/diazo/css"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:xi="http://www.w3.org/2001/XInclude">
+    xmlns:xi="http://www.w3.org/2001/XInclude"
+    if-content="/html/body[@id='visual-portal-wrapper']">
 
   <!-- Import Barceloneta rules -->
   <xi:include href="++theme++barceloneta/rules.xml" />

--- a/+package.dottedname+/resources/src/+theme.folder+/webpack.xml
+++ b/+package.dottedname+/resources/src/+theme.folder+/webpack.xml
@@ -4,11 +4,12 @@
   xmlns:css="http://namespaces.plone.org/diazo/css">
 
   <!-- Drop default stylesheets and scripts -->
-  <drop content="//link[@rel='stylesheet']|//script" />
+  <drop content="//link[@rel='stylesheet']" />
+  <drop content="//script" />
 
   <!-- Move scripts within body after bundle -->
   <after theme-children="/html/body" method="raw"
-           content="/html/head/script[not(@src)]" />
+         content="/html/head/script[not(@src)]" />
   <after theme-children="/html/body" method="raw"
          content="/html/body//script" />
 

--- a/+package.dottedname+/resources/src/+theme.folder+/webpack.xml
+++ b/+package.dottedname+/resources/src/+theme.folder+/webpack.xml
@@ -8,6 +8,8 @@
 
   <!-- Move scripts within body after bundle -->
   <after theme-children="/html/body" method="raw"
+           content="/html/head/script[not(@src)]" />
+  <after theme-children="/html/body" method="raw"
          content="/html/body//script" />
 
   <!-- Drop logged-in bundles for anonymous users -->


### PR DESCRIPTION
A minor change

* Fix include inline javascripts from head

And strange workarounds for properly conditioning rules.

* Inline OR in xpath ``//link[@rel='stylesheet']|//script`` disabled visual-portal-wrapper-condition for that rule. That's probably because of how Diazo forms final XSLT rules

* Explict visual-portal-wrapper condition in rules root node works better than  ``<notheme />`` rule included Barceloneta rules. No ideas, how's that.