### PR TITLE
Fix build by adding missing dependencies and npm scripts

### DIFF
--- a/+package.dottedname+/buildout.cfg.bob
+++ b/+package.dottedname+/buildout.cfg.bob
@@ -1,6 +1,7 @@
 [buildout]
 extends = https://dist.plone.org/release/{{{ plone.version }}}/versions.cfg
 parts = instance plonesite
+versions = versions
 
 [instance]
 recipe = plone.recipe.zope2instance
@@ -19,3 +20,6 @@ default-language = en
 products-initial =
     plone.app.contenttypes
     rapido.plone
+
+[versions]
+plone.resource = 1.2

--- a/+package.dottedname+/resources/Makefile.bob
+++ b/+package.dottedname+/resources/Makefile.bob
@@ -10,10 +10,10 @@ SOURCES = \
 all: build
 
 build: clean node_modules $(SOURCES)
-	webpack
+  npm run build
 
 watch: clean node_modules $(SOURCES)
-	webpack-dev-server
+  npm run watch
 
 clean:
 	$(RM) -r theme

--- a/+package.dottedname+/resources/package.json.bob
+++ b/+package.dottedname+/resources/package.json.bob
@@ -8,6 +8,7 @@
     "babel-preset-react": "^6.5.0",
     "css-loader": "^0.14.5",
     "exports-loader": "^0.6.3",
+    "file-loader": "^0.9.0",
 {{% if theme.svg %}}
     "fontello-svg": "^0.5.0",
 {{% endif %}}
@@ -25,5 +26,9 @@
   },
   "dependencies": {
     "brace": "^0.8.0"
-  }
+  },
+  "scripts": {
+    "watch": "webpack-dev-server",
+    "build": "webpack"
+   }
 }


### PR DESCRIPTION
rapido.plone 1.1 require a pin on plone.resource
Better wrap webpack in npm scripts for not use the global one.
file-loader was missing from package.json.

/cc @datakurre @ebrehault AMAZING work. I wanted to try it a long time ago. Any plans to update it to webpack 2.2? Next steps?